### PR TITLE
eval-all.sh: support setting FLAKE_REGRESSION_GLOB to an ipath matcher

### DIFF
--- a/eval-all.sh
+++ b/eval-all.sh
@@ -12,4 +12,4 @@ export CACHE_RUNS=1
 
 nix store info
 
-find tests -mindepth 3 -maxdepth 3 -type d -iname "${FLAKE_REGRESSION_GLOB:-*}" -not -path '*/.*' | sort | head -n${MAX_FLAKES:-1000000} | parallel ./eval-flake.sh
+find tests -mindepth 3 -maxdepth 3 -type d -ipath "tests/${FLAKE_REGRESSION_GLOB:-*}" -not -path '*/.*' | sort | head -n${MAX_FLAKES:-1000000} | parallel ./eval-flake.sh


### PR DESCRIPTION
This allows callers to pick a subset of flakes to test.