### PR TITLE
Revert "Test with GC settings that are more likely to expose Nix GC bugs"

### DIFF
--- a/eval-flake.sh
+++ b/eval-flake.sh
@@ -64,7 +64,7 @@ fi
 
 echo "Evaluating $locked_url..." >&2
 
-if ! GC_FREE_SPACE_DIVISOR=69 GC_ENABLE_INCREMENTAL=1 GC_INITIAL_HEAP_SIZE=16M nix eval --show-trace --no-allow-import-from-derivation --min-free 1000000000 --json "path:$(realpath "$tmp_dir")#contents" > "$eval_out" 2> "$flake_dir/eval.stderr"; then
+if ! nix eval --show-trace --no-allow-import-from-derivation --min-free 1000000000 --json "path:$(realpath "$tmp_dir")#contents" > "$eval_out" 2> "$flake_dir/eval.stderr"; then
     echo "Flake $locked_url failed to evaluate:" >&2
     cat "$flake_dir/eval.stderr" >&2
     error_handler


### PR DESCRIPTION
This reverts commit 98047deb34ea50a71511072b8af665f2bf84119c.

While useful for catching GC bugs, the impact on eval time was a bit too much (e.g. flake-regressions/tests/NixOS/nix/2.21.2/ taking 19m9s instead of 3m0s).